### PR TITLE
Add custom Security Support Provider/Authentication Package (SSP/AP)

### DIFF
--- a/CustomAuthPkg/.gitignore
+++ b/CustomAuthPkg/.gitignore
@@ -1,0 +1,2 @@
+/x64
+/*.vcxproj.user

--- a/CustomAuthPkg/CustomAuthPkg.vcxproj
+++ b/CustomAuthPkg/CustomAuthPkg.vcxproj
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{80720839-ef56-49fb-8397-4bfd6b903fa5}</ProjectGuid>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/CustomAuthPkg/CustomAuthPkg.vcxproj.filters
+++ b/CustomAuthPkg/CustomAuthPkg.vcxproj.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Main.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+</Project>

--- a/CustomAuthPkg/Install.bat
+++ b/CustomAuthPkg/Install.bat
@@ -1,0 +1,11 @@
+:: Fix issue with "Run as Administrator" current dir
+cd /d "%~dp0"
+
+echo Installing authentication package DLL...
+
+copy CustomAuthPkg.dll %SYSTEMROOT%\System32
+
+
+reg.exe add "HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" /v "Security Packages" /t REG_MULTI_SZ /d CustomAuthPkg\0 /f
+
+pause

--- a/CustomAuthPkg/Main.cpp
+++ b/CustomAuthPkg/Main.cpp
@@ -1,0 +1,16 @@
+#include <windows.h>
+
+BOOL APIENTRY DllMain( HMODULE /*hModule*/,
+                       DWORD  ul_reason_for_call,
+                       LPVOID /*lpReserved*/)
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}

--- a/CustomAuthPkg/Main.cpp
+++ b/CustomAuthPkg/Main.cpp
@@ -1,16 +1,241 @@
+#include <ntstatus.h>
+#define WIN32_NO_STATUS
 #include <windows.h>
+#define SECURITY_WIN32 // required by sspi.h
+#include <sspi.h>
+#include <NTSecAPI.h>  // for LSA_STRING
+#include <ntsecpkg.h>  // for LSA_DISPATCH_TABLE
+#include <cassert>
+#include <fstream>
 
-BOOL APIENTRY DllMain( HMODULE /*hModule*/,
-                       DWORD  ul_reason_for_call,
-                       LPVOID /*lpReserved*/)
+// exported symbols
+#pragma comment(linker, "/export:SpLsaModeInitialize" )
+
+#pragma warning(disable: 4100) // unreferenced formal parameter
+
+
+LSA_DISPATCH_TABLE DispatchTable;
+LSA_STRING         PackageName;
+
+void LogMessage(const char* message) {
+#ifdef NDEBUG
+    message;
+#else
+    // append to log
+    std::ofstream logFile("C:\\CustomAuthPkg_log.txt", std::ios_base::app);
+    logFile << message;
+    logFile << "\n";
+#endif
+}
+
+LSA_STRING CreateLsaString(const char msg[]) {
+    USHORT msg_len = sizeof(msg) - 1; // exclude null-termination
+
+    LSA_STRING str{};
+    str.Buffer = (char*)DispatchTable.AllocateLsaHeap(msg_len);
+    strcpy_s(str.Buffer, msg_len, msg);
+    str.Length = msg_len;
+    str.MaximumLength = msg_len;
+    return str;
+}
+
+// LSA calls LsaApInitializePackage() when loading AuthPkg DLL
+NTSTATUS LsaApInitializePackage(ULONG AuthenticationPackageId,
+    PLSA_DISPATCH_TABLE LsaDispatchTable,
+    PLSA_STRING Database,
+    PLSA_STRING Confidentiality,
+    PLSA_STRING* AuthenticationPackageName
+) {
+    LogMessage("LsaApInitializePackage");
+
+    DispatchTable = *LsaDispatchTable; // copy function pointer table
+
+    PackageName = CreateLsaString("CustomAuthPkg");
+    (*AuthenticationPackageName) = &PackageName;
+
+    return 0;
+}
+
+NTSTATUS NTAPI SpInitialize(ULONG_PTR PackageId, SECPKG_PARAMETERS* Parameters, LSA_SECPKG_FUNCTION_TABLE* FunctionTable) {
+    LogMessage("SpInitialize");
+    return 0;
+}
+
+NTSTATUS NTAPI SpShutDown() {
+    LogMessage("SpShutDown");
+    return 0;
+}
+
+NTSTATUS NTAPI SpGetInfo(SecPkgInfoW* PackageInfo) {
+    LogMessage("SpGetInfo");
+
+    PackageInfo->fCapabilities = SECPKG_FLAG_ACCEPT_WIN32_NAME | SECPKG_FLAG_CONNECTION;
+    PackageInfo->wVersion = 1;
+    PackageInfo->wRPCID = SECPKG_ID_NONE;
+    PackageInfo->cbMaxToken = 0;
+    PackageInfo->Name = (SEC_WCHAR*)L"CustomAuthPkg";
+    PackageInfo->Comment = (SEC_WCHAR*)L"CustomAuthPkg";
+
+    return 0;
+}
+
+NTSTATUS LsaApLogonUser(PLSA_CLIENT_REQUEST ClientRequest,
+    SECURITY_LOGON_TYPE LogonType,
+    VOID* AuthenticationInformation,
+    VOID* ClientAuthenticationBase,
+    ULONG AuthenticationInformationLength,
+    VOID** ProfileBuffer,
+    ULONG* ProfileBufferLength,
+    LUID* LogonId,
+    NTSTATUS* SubStatus,
+    LSA_TOKEN_INFORMATION_TYPE* TokenInformationType,
+    VOID** TokenInformation,
+    LSA_UNICODE_STRING** AccountName,
+    LSA_UNICODE_STRING** AuthenticatingAuthority)
 {
-    switch (ul_reason_for_call)
-    {
-    case DLL_PROCESS_ATTACH:
-    case DLL_THREAD_ATTACH:
-    case DLL_THREAD_DETACH:
-    case DLL_PROCESS_DETACH:
-        break;
-    }
-    return TRUE;
+    LogMessage("LsaApLogonUser");
+    return 0;
+}
+
+NTSTATUS LsaApLogonUserEx(
+    PLSA_CLIENT_REQUEST ClientRequest,
+    SECURITY_LOGON_TYPE LogonType,
+    VOID* AuthenticationInformation,
+    VOID* ClientAuthenticationBase,
+    ULONG AuthenticationInformationLength,
+    VOID** ProfileBuffer,
+    ULONG* ProfileBufferLength,
+    LUID* LogonId,
+    NTSTATUS* SubStatus,
+    LSA_TOKEN_INFORMATION_TYPE* TokenInformationType,
+    VOID** TokenInformation,
+    PUNICODE_STRING* AccountName,
+    PUNICODE_STRING* AuthenticatingAuthority,
+    PUNICODE_STRING* MachineName)
+{
+    LogMessage("LsaApLogonUserEx");
+    return 0;
+}
+
+NTSTATUS LsaApLogonUserEx2(
+    PLSA_CLIENT_REQUEST ClientRequest,
+    SECURITY_LOGON_TYPE LogonType,
+    VOID* ProtocolSubmitBuffer,
+    VOID* ClientBufferBase,
+    ULONG SubmitBufferSize,
+    VOID** ProfileBuffer,
+    ULONG* ProfileBufferSize,
+    LUID* LogonId,
+    NTSTATUS* SubStatus,
+    LSA_TOKEN_INFORMATION_TYPE* TokenInformationType,
+    VOID** TokenInformation,
+    PUNICODE_STRING* AccountName,
+    PUNICODE_STRING* AuthenticatingAuthority,
+    PUNICODE_STRING* MachineName,
+    SECPKG_PRIMARY_CRED* PrimaryCredentials,
+    SECPKG_SUPPLEMENTAL_CRED_ARRAY** SupplementalCredentials)
+{
+    LogMessage("LsaApLogonUserEx2");
+    return 0;
+}
+
+NTSTATUS LsaApCallPackage(PLSA_CLIENT_REQUEST ClientRequest,
+    VOID* ProtocolSubmitBuffer,
+    VOID* ClientBufferBase,
+    ULONG SubmitBufferLength,
+    VOID** ProtocolReturnBuffer,
+    ULONG* ReturnBufferLength,
+    NTSTATUS* ProtocolStatus)
+{
+    LogMessage("LsaApCallPackage");
+    return 0;
+}
+
+void LsaApLogonTerminated(LUID* LogonId) {
+    LogMessage("LsaApLogonTerminated");
+}
+
+NTSTATUS LsaApCallPackageUntrusted(
+    PLSA_CLIENT_REQUEST ClientRequest,
+    VOID*               ProtocolSubmitBuffer,
+    VOID*               ClientBufferBase,
+    ULONG               SubmitBufferLength,
+    VOID** ProtocolReturnBuffer,
+    ULONG*              ReturnBufferLength,
+    NTSTATUS*           ProtocolStatus)
+{
+    LogMessage("LsaApCallPackageUntrusted");
+    return 0;
+}
+
+NTSTATUS LsaApCallPackagePassthrough(
+    PLSA_CLIENT_REQUEST ClientRequest,
+    VOID* ProtocolSubmitBuffer,
+    VOID* ClientBufferBase,
+    ULONG SubmitBufferLength,
+    VOID** ProtocolReturnBuffer,
+    ULONG* ReturnBufferLength,
+    NTSTATUS* ProtocolStatus)
+{
+    LogMessage("LsaApCallPackagePassthrough");
+    return 0;
+}
+
+
+SECPKG_FUNCTION_TABLE SecurityPackageFunctionTable = {
+    LsaApInitializePackage,
+    LsaApLogonUser,
+    LsaApCallPackage,
+    LsaApLogonTerminated,
+    LsaApCallPackageUntrusted,
+    LsaApCallPackagePassthrough,
+    LsaApLogonUserEx,
+    LsaApLogonUserEx2,
+    SpInitialize,
+    SpShutDown,
+    SpGetInfo,
+    NULL, // SpAcceptCredentialsFn
+    NULL, // SpAcquireCredentialsHandleFn
+    NULL, // SpQueryCredentialsAttributesFn
+    NULL, // SpFreeCredentialsHandleFn
+    NULL, // SpSaveCredentialsFn
+    NULL, // SpGetCredentialsFn
+    NULL, // SpDeleteCredentialsFn
+    NULL, // SpInitLsaModeContextFn
+    NULL, // SpAcceptLsaModeContextFn
+    NULL, // SpDeleteContextFn
+    NULL, // SpApplyControlTokenFn
+    NULL, // SpGetUserInfoFn
+    NULL, // SpGetExtendedInformationFn
+    NULL, // SpQueryContextAttributesFn
+    NULL, // SpAddCredentialsFn
+    NULL, // SpSetExtendedInformationFn
+    NULL, // SpSetContextAttributesFn
+    NULL, // SpSetCredentialsAttributesFn
+    NULL, // SpChangeAccountPasswordFn
+    NULL, // SpQueryMetaDataFn
+    NULL, // SpExchangeMetaDataFn
+    NULL, // SpGetCredUIContextFn
+    NULL, // SpUpdateCredentialsFn
+    NULL, // SpValidateTargetInfoFn
+    NULL, // LSA_AP_POST_LOGON_USER
+    NULL, // SpGetRemoteCredGuardLogonBufferFn
+    NULL, // SpGetRemoteCredGuardSupplementalCredsFn
+    NULL, // SpGetTbalSupplementalCredsFn
+    NULL, // PLSA_AP_LOGON_USER_EX3
+    NULL, // PLSA_AP_PRE_LOGON_USER_SURROGATE
+    NULL, // PLSA_AP_POST_LOGON_USER_SURROGATE
+    NULL, // SpExtractTargetInfoFn
+};
+
+// LSA calls SpLsaModeInitialize() when loading SSP DLL
+extern "C"
+NTSTATUS NTAPI SpLsaModeInitialize(ULONG LsaVersion, ULONG* PackageVersion, SECPKG_FUNCTION_TABLE** ppTables, ULONG* pcTables) {
+    LogMessage("SpLsaModeInitialize");
+
+    *PackageVersion = SECPKG_INTERFACE_VERSION;
+    *ppTables = &SecurityPackageFunctionTable;
+    *pcTables = 1;
+
+    return STATUS_SUCCESS;
 }

--- a/CustomAuthPkg/README.md
+++ b/CustomAuthPkg/README.md
@@ -1,0 +1,22 @@
+# Security Support Provider/Authentication Package (SSP/AP) sample
+Minimal Security Support Provider/Authentication Package (SSP/AP) that does nothing.
+
+## Prerequisite
+Local Security Authority (LSA) protection needs to be disabled in order for the DLL to load.
+
+#### Instructions
+* Open "Windows Security"
+* Click on "Device security"
+* Click on "Core isolation"
+* Turn off "Local Security Authority protection"
+* Reboot
+
+## Installation
+Run `install.bat` as admin.
+
+## External links
+* [Registering SSP/AP DLLs](https://learn.microsoft.com/en-us/windows/win32/secauthn/registering-ssp-ap-dlls) 
+* [LSA Mode Initialization](https://learn.microsoft.com/en-us/windows/win32/secauthn/lsa-mode-initialization)
+* [SpLsaModeInitialize](https://learn.microsoft.com/en-us/windows/win32/api/ntsecpkg/nc-ntsecpkg-splsamodeinitializefn) entry point
+* [SECPKG_FUNCTION_TABLE](https://learn.microsoft.com/en-us/windows/win32/api/ntsecpkg/ns-ntsecpkg-secpkg_function_table) function dispatch table
+* [Functions Implemented by Authentication Packages](https://learn.microsoft.com/en-us/windows/win32/secauthn/authentication-functions#functions-implemented-by-authentication-packages)

--- a/ReversePassword.sln
+++ b/ReversePassword.sln
@@ -11,6 +11,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PasswordChanger", "Password
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BluetoothSubauthPkg", "BluetoothSubauthPkg\BluetoothSubauthPkg.vcxproj", "{1CD90121-15AC-4218-973B-1EF512439669}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CustomAuthPkg", "CustomAuthPkg\CustomAuthPkg.vcxproj", "{80720839-EF56-49FB-8397-4BFD6B903FA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -33,6 +35,10 @@ Global
 		{1CD90121-15AC-4218-973B-1EF512439669}.Debug|x64.Build.0 = Debug|x64
 		{1CD90121-15AC-4218-973B-1EF512439669}.Release|x64.ActiveCfg = Release|x64
 		{1CD90121-15AC-4218-973B-1EF512439669}.Release|x64.Build.0 = Release|x64
+		{80720839-EF56-49FB-8397-4BFD6B903FA5}.Debug|x64.ActiveCfg = Debug|x64
+		{80720839-EF56-49FB-8397-4BFD6B903FA5}.Debug|x64.Build.0 = Debug|x64
+		{80720839-EF56-49FB-8397-4BFD6B903FA5}.Release|x64.ActiveCfg = Release|x64
+		{80720839-EF56-49FB-8397-4BFD6B903FA5}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The SSP/AP package doesn't do anything useful yet. It just logs incoming API calls to `C:\CustomAuthPkg_log.txt`.

<img width="750" height="384" alt="image" src="https://github.com/user-attachments/assets/4c276511-4deb-4979-a966-0b8432823f41" />

```
Package: CustomAuthPkg
* Comment: Custom security package for testing
* Capabilities: FLAG_INTEGRITY |FLAG_PRIVACY |FLAG_TOKEN_ONLY |FLAG_DATAGRAM |FLAG_CONNECTION |FLAG_MULTI_REQUIRED |FLAG_CLIENT_ONLY |FLAG_EXTENDED_ERROR |FLAG_IMPERSONATION |FLAG_ACCEPT_WIN32_NAME |FLAG_STREAM |FLAG_NEGOTIABLE |FLAG_GSS_COMPATIBLE |FLAG_LOGON |FLAG_ASCII_BUFFERS |FLAG_FRAGMENT |FLAG_MUTUAL_AUTH |FLAG_DELEGATION |FLAG_READONLY_WITH_CHECKSUM |FLAG_RESTRICTED_TOKENS |FLAG_NEGO_EXTENDER |FLAG_NEGOTIABLE2 |FLAG_APPCONTAINER_PASSTHROUGH |FLAG_APPCONTAINER_CHECKS |CALLFLAGS_APPCONTAINER |CALLFLAGS_FORCE_SUPPLIED |
```